### PR TITLE
Group parents/children, some minor fixes

### DIFF
--- a/src/main/java/de/jeff_media/LightPerms/Commands.java
+++ b/src/main/java/de/jeff_media/LightPerms/Commands.java
@@ -354,6 +354,7 @@ public class Commands implements CommandExecutor {
                 s.sendMessage("§3- §bremove <permission> §3- remove permission from a group");
                 s.sendMessage("§3- §baddmember <user> §3- add user to a group");
                 s.sendMessage("§3- §bremovemember <user> §3- remove user from a group");
+                s.sendMessage("§3- §bfamily §3- show parents/children of a group");
                 s.sendMessage("§3- §baddparent <group> §3- add parent group to group");
                 s.sendMessage("§3- §bremoveparent <group> §3- remove parent group to group");
                 break;

--- a/src/main/java/de/jeff_media/LightPerms/Commands.java
+++ b/src/main/java/de/jeff_media/LightPerms/Commands.java
@@ -119,6 +119,10 @@ public class Commands implements CommandExecutor {
                 return addGroupPermission(args[0], args[2], sender);
             case "remove":
                 return removeGroupPermission(args[0], args[2], sender);
+            case "addparent":
+                return addGroupParent();
+            case "removeparent" || "remparent":
+                return removeGroupParent()
         }
 
         if (args[1].equalsIgnoreCase("addmember") || args[1].equalsIgnoreCase("removemember")) {
@@ -303,6 +307,8 @@ public class Commands implements CommandExecutor {
                 s.sendMessage("§3- §bremove <permission> §3- remove permission from a group");
                 s.sendMessage("§3- §baddmember <user> §3- add user to a group");
                 s.sendMessage("§3- §bremovemember <user> §3- remove user from a group");
+                s.sendMessage("§3- §baddparent <group> §3- add parent group to group");
+                s.sendMessage("§3- §bremoveparent <group> §3- remove parent group to group");
                 break;
         }
     }

--- a/src/main/java/de/jeff_media/LightPerms/LightPerms.java
+++ b/src/main/java/de/jeff_media/LightPerms/LightPerms.java
@@ -3,7 +3,6 @@ package de.jeff_media.LightPerms;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -21,7 +20,6 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -36,7 +34,7 @@ public class LightPerms extends JavaPlugin implements Listener, CommandExecutor 
 
         perms = new HashMap<>();
         getServer().getPluginManager().registerEvents(this, this);
-        getCommand("lp").setTabCompleter(new TabCompleter());
+        getCommand("lp").setTabCompleter(new TabCompleter(this));
         getCommand("lp").setExecutor(new Commands(this));
 
         addPermsToOnlinePlayers();
@@ -94,7 +92,6 @@ public class LightPerms extends JavaPlugin implements Listener, CommandExecutor 
         getLogger().warning(text);
     }
 
-
     public void addPermissions(Player p) {
         PermissionAttachment attachment = p.addAttachment(this);
 
@@ -109,12 +106,17 @@ public class LightPerms extends JavaPlugin implements Listener, CommandExecutor 
                 attachment.setPermission(perm, true);
                 //System.out.println(" Adding " + perm + " to " + p.getName() + " because group " + group);
             }
+            for (String parent : getConfig().getStringList("groups." + group + ".parents"))
+                for (String perm : getConfig().getStringList("groups." + parent + ".permissions")) {
+                    attachment.setPermission(perm, true);
+                    //System.out.println(" Adding " + perm + " to " + p.getName() + " because group " + group);
+                }
         }
+
         for (String perm : getConfig().getStringList("users." + p.getName() + ".permissions")) {
             attachment.setPermission(perm, true);
             //System.out.println("Adding " + perm + " to " + p.getName() + " because player");
         }
-
 
         perms.put(p.getUniqueId(), attachment);
         if (getMcVersion()>=13) {

--- a/src/main/java/de/jeff_media/LightPerms/TabCompleter.java
+++ b/src/main/java/de/jeff_media/LightPerms/TabCompleter.java
@@ -1,14 +1,23 @@
 package de.jeff_media.LightPerms;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public class TabCompleter implements org.bukkit.command.TabCompleter {
+
+    final LightPerms main;
+
+    TabCompleter(LightPerms main) {
+        this.main = main;
+    }
+
     final String[] commands = new String[] {
             "user","group","listgroups","reload"
     };
@@ -16,7 +25,7 @@ public class TabCompleter implements org.bukkit.command.TabCompleter {
             "add","remove","addgroup","removegroup","info"
     };
     final String[] group = new String[] {
-            "add","remove","info","listmembers","addmember","removemember"
+            "add","remove","info","addmember","removemember", "family", "addparent", "removeparent",
     };
     final String[] defaultGroup = new String[] {
             "add","remove","info"
@@ -29,11 +38,15 @@ public class TabCompleter implements org.bukkit.command.TabCompleter {
         }
         switch(args[0].toLowerCase()) {
             case "user":
-                if(args.length==2) return null;
+                List<String> players = new ArrayList<>();
+                Bukkit.getServer().getOnlinePlayers().forEach(player -> players.add(player.getName()));
+                if(args.length==2) return players;
                 if(args.length==3) return Arrays.asList(user);
                 return null;
             case "group":
-                if(args.length==2) return null;
+                List<String> groups = new ArrayList<>();
+                groups.addAll(main.getConfig().getConfigurationSection("groups").getKeys(false));
+                if(args.length==2) return groups;
                 if(args.length==3) return Arrays.asList(group);
                 return null;
             case "listgroups":


### PR DESCRIPTION
Hello, I wrote some simple stuff in similar style to what you write, and added group parents and tab completion for groups / players, command additions/modifications:
`/lp group (group)` now redirects to its info page since `/lp group` shows group usage anyways
`/lp group (group) family` shows its parents and children
`/lp group (group) addparent (parent)` adds a parent group
`/lp group (group) removeparent (parent)` remove a parent group

Hope you find this helpful